### PR TITLE
added appache and removed whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Defaults all routes to ` index.html ` in the directory set by ` setDirectory() `
 * eot
 * ttf
 * woff
+* appcache
 
 For example, the route ` /some/pushstate/route ` will return the ` index.html ` file. But, ` /some/static/path/logo.png ` will return the ` logo.png ` static file.
 
@@ -40,7 +41,7 @@ server.start({
 
 ##### options
 
-* `port` 
+* `port`
   * set the port that the server should open
   * uses ` process.env.PORT ` if not specified, and defaults to port ` 9000 ` if none is available
   * * optionally use `server.port()`

--- a/index.js
+++ b/index.js
@@ -6,27 +6,27 @@ var app = connect();
 module.exports = {
   _port: 9000,
   _directory: 'public',
-  
+
   port: function (port) {
     this._port = port;
   },
-  
+
   directory: function (dir) {
     this._directory = dir;
   },
-  
+
   start: function (options) {
     options = options || {};
-    
+
     var port = process.env.PORT || options.port || this._port;
     var directory = options.directory || this._directory;
-    
+
     app.use(modRewrite([
-      '!\\.html|\\.js|\\.css|\\.png|\\.svg|\\.eot|\\.ttf|\\.woff /index.html [L]'
+      '!\\.html|\\.js|\\.css|\\.png|\\.svg|\\.eot|\\.ttf|\\.woff|\\.appcache /index.html [L]'
     ]));
     app.use(connect.compress());
     app.use(connect.static(directory));
-    
+
     app.listen(port, function () {
       console.log('\nPushstate server started on port ' + port + '\n');
     });


### PR DESCRIPTION
Using this to kick the tires with webpack plugins, need appcache to pass through to use lettertwo/appcache-webpack-plugin
