### PR TITLE
Add support for woff2, mp4, and webm

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,14 @@ Defaults all routes to ` index.html ` in the directory set by ` setDirectory() `
 * eot
 * ttf
 * woff
+* woff2
 * appcache
 * jpg
 * jpeg
 * gif
 * ico
+* mp4
+* webm
 
 For example, the route ` /some/pushstate/route ` will return the ` index.html ` file. But, ` /some/static/path/logo.png ` will return the ` logo.png ` static file.
 

--- a/index.js
+++ b/index.js
@@ -31,7 +31,9 @@ module.exports = {
     var file = options.file || this._file;
 
     app.use(modRewrite([
-      '!\\.html|\\.js|\\.json|\\.ico|\\.csv|\\.css|\\.less|\\.png|\\.svg|\\.eot|\\.ttf|\\.woff|\\.appcache|\\.jpg|\\.jpeg|\\.gif ' + file + ' [L]'
+      '!\\.html|\\.js|\\.json|\\.ico|\\.csv|\\.css|\\.less|\\.png|\\.svg' +
+      '|\\.eot|\\.ttf|\\.woff|\\.woff2|\\.appcache|\\.jpg|\\.jpeg|\\.gif' +
+      '|\\.mp4|\\.webm ' + file + ' [L]'
     ]));
     app.use(compression());
 


### PR DESCRIPTION
I added support for `woff2`, `mp4`, and `webm`.
The line was getting very long, so I split it into three.