### PR TITLE
Return underlying server after calling listen

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = {
       app.use(serveStatic(directory));
     });
 
-    app.listen(port, function () {
+    return app.listen(port, function () {
       console.log('\nPushstate server started on port ' + port + '\n');
     });
   }


### PR DESCRIPTION
This is so you can call:

```js
const pushstate = require('pushstate-server');
const server = pushstate.start({
  port: 2999,
  directories: ['./build']
});
/* some time later */
server.close()
```

Useful for something I'm building. Otherwise the only way to quit the server is to send an `INT` (I think...)