### PR TITLE
Change reported host from localhost to ::

### DIFF
--- a/bin/pushstate-server
+++ b/bin/pushstate-server
@@ -12,5 +12,5 @@ server.start({
   port: process.argv[3],
   file: process.argv[4]
 }, function(err, port) {
-    console.log(`Listening on port ${port} (http://localhost:${port})`);
+    console.log(`Listening on port ${port} (http://:::${port})`);
 });


### PR DESCRIPTION
pushstate-server and the cli seem to listen to all hosts (`::` in ipv6) instead of just localhost. The cli tells the user that it is listening only on localhost, which is inaccurate.

I ran into this while trying out `create-react-app`'s deployment workflow, which suggests using `pushstate-server`.
