### PR TITLE
Option to add custom middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ server.start({
 });
 ```
 
+or add some middleware
+
+```js
+server.start({
+  middleware: [
+    someMiddleware,
+    ['/route', someRouteSpecificMiddleware ]
+  ]
+});
+```
+
 
 ## Global Install
 
@@ -69,3 +80,6 @@ usage: pushstate-server [directory] [port]
 * `file`
   * Custom file to serve
   * defaults to `index.html`
+* `middleware`
+  * array of middleware to use; each array element can be a function or an array of arguments for [`connect`'s `use` method](https://github.com/senchalabs/connect#use-middleware)
+  * defaults to `[]`

--- a/index.js
+++ b/index.js
@@ -20,9 +20,16 @@ exports.start = function (options, _onStarted) {
   let directories = options.directories || [directory]
   let file = options.file || FILE
   let host = options.host || HOST
+  let middleware = options.middleware || []
   let onStarted = _onStarted || function () {}
 
   app.use(compression())
+
+  // Add custom middleware
+  middleware.forEach(function(item) {
+    if (!Array.isArray(item)) item = [item]
+    app.use.apply(app, item)
+  })
 
   // First, check the file system
   directories.forEach(function(directory) {


### PR DESCRIPTION
First, let me just say thanks for all your hard work on this!

I've come across a couple of instances where it I've needed to install some basic middleware - eg logging or authentication. While these can be handled on a case-by-case basis (eg #46), I think including a generic way of adding middleware would be both safe and useful.

Please note that I've modified the tests so that a new `connect` app is created for each test, otherwise the middleware persists between tests.