### PR TITLE
Add ability to launch server trough HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@ server.start({
 });
 ```
 
+or for https connection
+
+```js
+var server = require('pushstate-server');
+
+server.start({
+  port: 4200,
+  directory: './public',
+  useSSL: true,
+  sslKeyPath: './server.key',
+  sslCertPath: './server.crt'
+});
+```
+
 or for multiple directories
 
 ```js
@@ -50,7 +64,7 @@ npm install -g pushstate-server
 ```
 
 ```
-usage: pushstate-server [-d directory] [-p port] [-f file]
+usage: pushstate-server [-d directory] [-p port] [-f file] [-s -c path/to/server.crt -k path/to/server.key]
 ```
 
 ## API
@@ -69,3 +83,10 @@ usage: pushstate-server [-d directory] [-p port] [-f file]
 * `file`
   * Custom file to serve
   * defaults to `index.html`
+* `useSSL`
+  * Let the server use HTTPS instead of HTTP
+  * defaults to `false`
+* `sslKeyPath`
+  * Path for the SSL private key
+* `sslCertPath`
+  * Path for the SSL certificate

--- a/bin/pushstate-server
+++ b/bin/pushstate-server
@@ -2,6 +2,7 @@
 
 const server = require('../index')
 const argv = require('minimist')(process.argv.slice(2))
+const fs = require('fs')
 
 if (argv.h || argv.help) {
 	console.log([
@@ -11,15 +12,39 @@ if (argv.h || argv.help) {
 		'  -d           Directory to serve [public]',
 		'  -p           Port to use [9000]',
 		'  -f           Custom file to serve [index.html]',
+		'  -s           Serve files trough https',
+		'  -c --cert    Path to SSL certificate',
+		'  -k --key     Path to SSL private key',
 		'  -h --help    Print this list and exit.'
 		].join('\n'));
 	process.exit();
 }
 
+if (argv.s) {
+	if (!argv.c) {
+		console.log('Missing SSL certificate path !')
+		process.exit()
+	} else if(!fs.existsSync(argv.c)) {
+		console.log('Invalid SSL certificate path !')
+		process.exit()
+	}
+
+	if (!argv.k) {
+		console.log('Missing SSL private key path !')
+		process.exit()
+	} else if(!fs.existsSync(argv.k)) {
+		console.log('Invalid SSL key path !')
+		process.exit()
+	}
+}
+
 server.start({
   directory: argv.d,
   port: argv.p,
-  file: argv.f
+	file: argv.f,
+	useSSL: argv.s,
+	sslCertPath: argv.c,
+	sslKeyPath: argv.k
 }, (err, address) =>
-  console.log(`Listening on port ${address.port} (http://${address.address}:${address.port})`)
+  console.log(`Listening on port ${address.port} (${argv.s ? 'https' : 'http'}://${address.address}:${address.port})`)
 )

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "compression": "1.7.0",
     "connect": "3.6.2",
     "connect-static-file": "1.2.0",
+    "fs": "0.0.1-security",
+    "https": "1.0.0",
     "minimist": "1.2.0",
     "serve-static": "1.12.3"
   },


### PR DESCRIPTION
With `-s -k path/to/server.key -c path/to/server.crt` the pushstate server will listen trough an encrypted connexion, drastically increasing security.

The user must provide his own SSL certificate and key.

New dependencies are only `https` and `fs`, which is required for reading on-disk files.