### PR TITLE
Add host option to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ npm install -g pushstate-server
 ```
 
 ```
-usage: pushstate-server [-d directory] [-p port] [-f file]
+usage: pushstate-server [-d directory] [-h host] [-p port] [-f file]
 ```
 
 ## API
@@ -60,6 +60,9 @@ usage: pushstate-server [-d directory] [-p port] [-f file]
 
 ##### options
 
+* `host`
+  * set the host that the server should open
+  * uses ` process.env.HOST ` if not specified, and defaults to host ` 0.0.0.0 ` if none is available
 * `port`
   * set the port that the server should open
   * uses ` process.env.PORT ` if not specified, and defaults to port ` 9000 ` if none is available

--- a/bin/pushstate-server
+++ b/bin/pushstate-server
@@ -3,21 +3,23 @@
 const server = require('../index')
 const argv = require('minimist')(process.argv.slice(2))
 
-if (argv.h || argv.help) {
+if (argv.help) {
 	console.log([
 		'usage: pushstate-server [options]',
 		'',
 		'options:',
 		'  -d           Directory to serve [public]',
+    '  -h           Host to use [0.0.0.0].',    
 		'  -p           Port to use [9000]',
 		'  -f           Custom file to serve [index.html]',
-		'  -h --help    Print this list and exit.'
+		'  --help       Print this list and exit.'
 		].join('\n'));
 	process.exit();
 }
 
 server.start({
   directory: argv.d,
+  host: argv.h,
   port: argv.p,
   file: argv.f
 }, (err, address) =>

--- a/index.js
+++ b/index.js
@@ -15,11 +15,11 @@ const HOST = "0.0.0.0";
 exports.start = function(options, _onStarted) {
   options = options || {};
 
+  let host = options.host || process.env.HOST || HOST;
   let port = options.port || process.env.PORT || PORT;
   let directory = options.directory || DIRECTORY;
   let directories = options.directories || [directory];
   let file = options.file || FILE;
-  let host = options.host || HOST;
   let onStarted = _onStarted || function() {};
 
   app.use(compression());

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pushstate-server",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Hello, @scottcorgan! It's very strange – server application has `host` option, but I can pass it from CLI.
I think, `-h` option for `host` – is okay, because `--help` option is still exists and has more semantic name than just `-h`.